### PR TITLE
Set all PWM as MAX after stop the skeleton service

### DIFF
--- a/meta-phosphor/common/recipes-phosphor/skeleton/skeleton/skeleton.service
+++ b/meta-phosphor/common/recipes-phosphor/skeleton/skeleton/skeleton.service
@@ -4,6 +4,7 @@ Description=Temp placeholder for skeleton function
 [Service]
 Restart=always
 ExecStart=/usr/sbin/system_manager.py
+ExecStopPost=/bin/sh -c "/usr/bin/find /sys/class/hwmon -follow -maxdepth 2 -type f -name 'pwm?' | xargs -i /bin/sh -c '/bin/echo 255 > {}'"
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Original request comes from openbmc#292

The fan control algorithm is belong to the skeleton service control
group and will be terminated once reboot.
So we maximize the fan speed after the process was terminated by
ExecStopPost.

Signed-off-by: johnhcwang hsienchiang@gmail.com
